### PR TITLE
Cr 1434 webform rate limit checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>census-int-rate-limiter-client</artifactId>
-  <version>0.0.8-SNAPSHOT</version>
+  <version>0.0.8-SNAPSHOT-CR1434</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Rate Limiter Client</name>
@@ -18,7 +18,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.integration</groupId>
     <artifactId>census-int-common-config</artifactId>
-    <version>0.0.16</version>
+    <version>0.0.17</version>
   </parent>
 
   <dependencies>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.68</version>
+      <version>0.0.72</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>census-int-rate-limiter-client</artifactId>
-  <version>0.0.8-SNAPSHOT-CR1434</version>
+  <version>0.0.8-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Rate Limiter Client</name>

--- a/src/main/java/uk/gov/ons/ctp/integration/ratelimiter/client/RateLimiterClient.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/ratelimiter/client/RateLimiterClient.java
@@ -306,7 +306,7 @@ public class RateLimiterClient {
     try {
       response =
           envoyLimiterRestClient.postResource(
-              RATE_LIMITER_QUERY_PATH, request, RateLimitResponse.class, "");
+              RATE_LIMITER_QUERY_PATH, request, RateLimitResponse.class);
 
     } catch (ResponseStatusException limiterException) {
       HttpStatus httpStatus = limiterException.getStatus();

--- a/src/main/java/uk/gov/ons/ctp/integration/ratelimiter/client/RateLimiterClient.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/ratelimiter/client/RateLimiterClient.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.domain.CaseType;
@@ -66,11 +68,13 @@ public class RateLimiterClient {
   private static final String RATE_LIMITER_QUERY_PATH = "/json";
 
   private RestClient envoyLimiterRestClient;
+  private CircuitBreaker circuitBreaker;
   private ObjectMapper objectMapper = new ObjectMapper();
 
-  public RateLimiterClient(RestClient envoyLimiterRestClient) {
+  public RateLimiterClient(RestClient envoyLimiterRestClient, CircuitBreaker circuitBreaker) {
     super();
     this.envoyLimiterRestClient = envoyLimiterRestClient;
+    this.circuitBreaker = circuitBreaker;
 
     this.objectMapper = new ObjectMapper();
     this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
@@ -79,11 +83,11 @@ public class RateLimiterClient {
   /**
    * Send fulfilment limit request to the limiter.
    *
-   * <p>If no limit has been breached then this method returns. If there is an internal error or if
+   * <p>If no limit has been breached then this method returns. If there is a validation error or if
    * a limit is breached then an exception is thrown.
    *
    * <p>All arguments must be non null and not empty, with the exception of the phone number which
-   * can be null if not known.
+   * can be null if not known, and the ipAddress which can be null.
    *
    * @param domain is the domain to query against. This value is mandatory.
    * @param product is the product used by the caller. This value is mandatory.
@@ -93,13 +97,12 @@ public class RateLimiterClient {
    * @param uprn is the uprn to limit requests against. This value is mandatory.
    * @param telNo is the end users telephone number. This value can be null, but if supplied then it
    *     cannot be an empty string.
-   * @return The response from the rate limiter.
-   * @throws CTPException if there is a processing error or if an invalid argument is supplied.
-   * @throws ResponseStatusException if the request to the limiter didn't return a 200. If a limit
-   *     has been breached then the exception status will be HttpStatus.TOO_MANY_REQUESTS and the
-   *     exception's reason field will contain the limiters json response.
+   * @throws CTPException if an invalid argument is supplied.
+   * @throws ResponseStatusException if the request limit has been breached. In this case the
+   *     exception status will be HttpStatus.TOO_MANY_REQUESTS and the exception's reason field will
+   *     contain the limiters json response.
    */
-  public RateLimitResponse checkFulfilmentRateLimit(
+  public void checkFulfilmentRateLimit(
       Domain domain,
       Product product,
       CaseType caseType,
@@ -140,54 +143,25 @@ public class RateLimiterClient {
     RateLimitRequest request = createRateLimitRequestForFulfilment(domain, params);
     log.with(request).debug("RateLimiterRequest for fulfilment");
 
-    // Send request to limiter, with detailed logging if we breached a limit
-    RateLimitResponse response;
-    try {
-      response =
-          envoyLimiterRestClient.postResource(
-              RATE_LIMITER_QUERY_PATH, request, RateLimitResponse.class, "");
-
-    } catch (ResponseStatusException limiterException) {
-      HttpStatus httpStatus = limiterException.getStatus();
-      if (httpStatus == HttpStatus.TOO_MANY_REQUESTS) {
-        // An expected failure scenario. Record the breach and make sure caller
-        // knows by re-throwing the exception
-        String breachDescription = describeLimitBreach(request, limiterException);
-        log.info(breachDescription.toString());
-        throw limiterException;
-      } else {
-        // Something unexpected went wrong
-        log.warn("Limiter request for fulfilments failed");
-        throw new CTPException(
-            Fault.SYSTEM_ERROR,
-            limiterException,
-            "POST request to limiter (for fulfilments) failed with http status: "
-                + httpStatus.value()
-                + "("
-                + httpStatus.name()
-                + ")");
-      }
-    }
-
-    return response;
+    // Send request to limiter
+    invokeRateLimiter("fulfilments", request);
   }
 
   /**
    * Send webform limit request to the limiter.
    *
-   * <p>If no limit has been breached then this method returns. If there is an internal error or if
+   * <p>If no limit has been breached then this method returns. If there is a validation error or if
    * a limit is breached then an exception is thrown.
    *
    * @param domain is the domain to query against. This value is mandatory.
    * @param ipAddress is the end users ip address. This value can be null, but if supplied then it
    *     cannot be an empty string.
-   * @return The response from the rate limiter, or null if the rate limiter was not called.
-   * @throws CTPException if there is a processing error or if an invalid argument is supplied.
-   * @throws ResponseStatusException if the request to the limiter didn't return a 200. If a limit
-   *     has been breached then the exception status will be HttpStatus.TOO_MANY_REQUESTS and the
-   *     exception's reason field will contain the limiters json response.
+   * @throws CTPException if there is an invalid argument is supplied.
+   * @throws ResponseStatusException if the request limit has been breached. In this case the
+   *     exception status will be HttpStatus.TOO_MANY_REQUESTS and the exception's reason field will
+   *     contain the limiters json response.
    */
-  public RateLimitResponse checkWebformRateLimit(Domain domain, String ipAddress)
+  public void checkWebformRateLimit(Domain domain, String ipAddress)
       throws CTPException, ResponseStatusException {
 
     // Fail if caller doesn't meet interface requirements
@@ -198,8 +172,8 @@ public class RateLimiterClient {
 
     // Skip check if RHUI has not been able to get the clients IP address
     if (ipAddress == null) {
-      log.debug("Not calling rate limiter");
-      return null;
+      log.debug("No IP Address. Not calling rate limiter");
+      return;
     }
 
     // Make it easy to access limiter parameters by adding to a hashmap
@@ -211,36 +185,8 @@ public class RateLimiterClient {
     RateLimitRequest request = createWebformRateLimitRequest(domain, params);
     log.with(request).debug("RateLimiterRequest for Webform");
 
-    // Send request to limiter, with detailed logging if we breached a limit
-    RateLimitResponse response;
-    try {
-      response =
-          envoyLimiterRestClient.postResource(
-              RATE_LIMITER_QUERY_PATH, request, RateLimitResponse.class, "");
-
-    } catch (ResponseStatusException limiterException) {
-      HttpStatus httpStatus = limiterException.getStatus();
-      if (httpStatus == HttpStatus.TOO_MANY_REQUESTS) {
-        // An expected failure scenario. Record the breach and make sure caller
-        // knows by re-throwing the exception
-        String breachDescription = describeLimitBreach(request, limiterException);
-        log.info(breachDescription.toString());
-        throw limiterException;
-      } else {
-        // Something unexpected went wrong
-        log.warn("Limiter request for Webform failed");
-        throw new CTPException(
-            Fault.SYSTEM_ERROR,
-            limiterException,
-            "POST request to limiter (for Webform) failed with http status: "
-                + httpStatus.value()
-                + "("
-                + httpStatus.name()
-                + ")");
-      }
-    }
-
-    return response;
+    // Send request to limiter
+    invokeRateLimiter("fulfilments", request);
   }
 
   // Throws CTPException is the argument is null
@@ -305,6 +251,88 @@ public class RateLimiterClient {
     limitDescriptor.setEntries(entries);
 
     return limitDescriptor;
+  }
+
+  /**
+   * Call the rate limiter using a circuit breaker. This will return without exception if 1) the
+   * request is within the rate limits, or 2) the call to the rate limiter fails in some way, or 3)
+   * due to previous failures the circuit breaker is 'open'. If the request is above the rate limits
+   * then a ResponseStatusException is thrown.
+   */
+  private void invokeRateLimiter(String requestDescription, RateLimitRequest request) {
+    ResponseStatusException limitException =
+        circuitBreaker.run(
+            () -> {
+              try {
+                doInvokeRateLimiter(requestDescription, request);
+                return null;
+              } catch (CTPException e) {
+                // we should get here if the rate-limiter is failing or not communicating
+                // ... wrap and rethrow to be handled by the circuit-breaker
+                throw new RuntimeException(e);
+              } catch (ResponseStatusException e) {
+                // we have got a 429 but don't rethrow it otherwise this will count against
+                // the circuit-breaker accounting, so instead we return it to later throw
+                // outside the circuit-breaker mechanism.
+                return e;
+              }
+            },
+            throwable -> {
+              // This is the Function for the circuitBreaker.run second parameter, which is called
+              // when an exception is thrown from the first Supplier parameter (above), including
+              // as part of the processing of being in the circuit-breaker OPEN state.
+              //
+              // It is OK to carry on, since it is better to tolerate limiter error than fail
+              // operation, however by getting here, the circuit-breaker has counted the failure,
+              // or we are in circuit-breaker OPEN state.
+              if (throwable instanceof CallNotPermittedException) {
+                log.info("Circuit breaker is OPEN calling rate limiter for " + requestDescription);
+              } else {
+                log.with("error", throwable.getMessage())
+                    .error(throwable, "Rate limiter failure for " + requestDescription);
+              }
+              return null;
+            });
+
+    if (limitException != null) {
+      throw limitException;
+    }
+  }
+
+  /** Make the rest call to the limiter */
+  private RateLimitResponse doInvokeRateLimiter(String requestDescription, RateLimitRequest request)
+      throws CTPException {
+    RateLimitResponse response;
+    try {
+      response =
+          envoyLimiterRestClient.postResource(
+              RATE_LIMITER_QUERY_PATH, request, RateLimitResponse.class, "");
+
+    } catch (ResponseStatusException limiterException) {
+      HttpStatus httpStatus = limiterException.getStatus();
+      if (httpStatus == HttpStatus.TOO_MANY_REQUESTS) {
+        // An expected failure scenario. Record the breach and make sure caller
+        // knows by re-throwing the exception
+        String breachDescription = describeLimitBreach(request, limiterException);
+        log.info(breachDescription.toString());
+        throw limiterException;
+      } else {
+        // Something unexpected went wrong
+        log.warn("Limiter request for " + requestDescription + " failed");
+        throw new CTPException(
+            Fault.SYSTEM_ERROR,
+            limiterException,
+            "POST request to limiter (for "
+                + requestDescription
+                + ") failed with http status: "
+                + httpStatus.value()
+                + "("
+                + httpStatus.name()
+                + ")");
+      }
+    }
+
+    return response;
   }
 
   // Builds a String which lists the LimitDescriptor(s) that triggered a limit breach

--- a/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClientFulfilmentTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClientFulfilmentTest.java
@@ -18,7 +18,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -69,8 +68,6 @@ public class RateLimiterClientFulfilmentTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     simulateCircuitBreaker();
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClientWebformTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClientWebformTest.java
@@ -1,26 +1,32 @@
 package uk.gov.ons.ctp.integration.ratelimiterclient;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.rest.RestClient;
 import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient;
 import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient.Domain;
@@ -34,10 +40,19 @@ import uk.gov.ons.ctp.integration.ratelimiter.model.RateLimitResponse;
 public class RateLimiterClientWebformTest {
 
   @Mock RestClient restClient;
+  @Mock private CircuitBreaker circuitBreaker;
 
-  @InjectMocks RateLimiterClient rateLimiterClient = new RateLimiterClient(restClient);
+  @InjectMocks
+  RateLimiterClient rateLimiterClient = new RateLimiterClient(restClient, circuitBreaker);
 
   private Domain domain = RateLimiterClient.Domain.RH;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    simulateCircuitBreaker();
+  }
 
   @Test
   public void checkWebformRateLimit_nullDomain() {
@@ -52,8 +67,7 @@ public class RateLimiterClientWebformTest {
 
   @Test
   public void checkWebformRateLimit_nullClientIP() throws ResponseStatusException, CTPException {
-    RateLimitResponse response = rateLimiterClient.checkWebformRateLimit(domain, null);
-    assertNull(response);
+    rateLimiterClient.checkWebformRateLimit(domain, null);
   }
 
   @Test
@@ -69,15 +83,12 @@ public class RateLimiterClientWebformTest {
 
   @Test
   public void checkWebformRateLimit_belowThreshold() throws CTPException {
-    // Rate limiter is going to be happy with limit request
-    RateLimitResponse fakeResponse = new RateLimitResponse();
-    Mockito.when(restClient.postResource(eq("/json"), any(), eq(RateLimitResponse.class), eq("")))
-        .thenReturn(fakeResponse);
+    // Don't need to mock the call to restClient.postResource() as default is treated as being below
+    // the limit
 
     // Run test
     String ipAddress = "123.123.123.123";
-    RateLimitResponse response = rateLimiterClient.checkWebformRateLimit(domain, ipAddress);
-    assertEquals(fakeResponse, response);
+    rateLimiterClient.checkWebformRateLimit(domain, ipAddress);
 
     // Grab the request sent to the limiter
     ArgumentCaptor<RateLimitRequest> limitRequestCaptor =
@@ -124,14 +135,9 @@ public class RateLimiterClientWebformTest {
     Mockito.when(restClient.postResource(eq("/json"), any(), eq(RateLimitResponse.class), eq("")))
         .thenThrow(failureException);
 
-    // Confirm that limiter request fails with expected CTPException
-    try {
-      rateLimiterClient.checkWebformRateLimit(domain, "11.134.234.64");
-      fail();
-    } catch (CTPException e) {
-      assertEquals(failureException, e.getCause());
-      assertEquals(Fault.SYSTEM_ERROR, e.getFault());
-    }
+    // Circuit breaker spots that this isn't a TOO_MANY_REQUESTS HttpStatus failure, so
+    // we log an error and allow the limit check to pass. ie, no exception thrown
+    rateLimiterClient.checkWebformRateLimit(domain, "11.134.234.64");
   }
 
   @Test
@@ -144,14 +150,9 @@ public class RateLimiterClientWebformTest {
     Mockito.when(restClient.postResource(eq("/json"), any(), eq(RateLimitResponse.class), eq("")))
         .thenThrow(failureException);
 
-    // Confirm that limiter request fails with a CTPException
-    try {
-      rateLimiterClient.checkWebformRateLimit(domain, "11.134.234.64");
-      fail();
-    } catch (CTPException e) {
-      assertTrue(e.getMessage().contains("Failed to parse"));
-      assertEquals(Fault.SYSTEM_ERROR, e.getFault());
-    }
+    // Although the rest client call fails the circuit breaker allows the limit check to pass. ie,
+    // no exception thrown
+    rateLimiterClient.checkWebformRateLimit(domain, "11.134.234.64");
   }
 
   private void verifyDescriptor(
@@ -167,5 +168,30 @@ public class RateLimiterClientWebformTest {
     DescriptorEntry entry = descriptor.getEntries().get(index);
     assertEquals(expectedKey, entry.getKey());
     assertEquals(expectedValue, entry.getValue());
+  }
+
+  private void simulateCircuitBreaker() {
+    doAnswer(
+            new Answer<Object>() {
+              @SuppressWarnings("unchecked")
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                Supplier<Object> runner = (Supplier<Object>) args[0];
+                Function<Throwable, Object> fallback = (Function<Throwable, Object>) args[1];
+
+                try {
+                  // execute the circuitBreaker.run first argument (the Supplier for the code you
+                  // want to run)
+                  return runner.get();
+                } catch (Throwable t) {
+                  // execute the circuitBreaker.run second argument (the fallback Function)
+                  fallback.apply(t);
+                }
+                return null;
+              }
+            })
+        .when(circuitBreaker)
+        .run(any(), any());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClientWebformTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClientWebformTest.java
@@ -18,7 +18,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -49,8 +48,6 @@ public class RateLimiterClientWebformTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     simulateCircuitBreaker();
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClient_IT.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClient_IT.java
@@ -7,8 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -22,7 +25,6 @@ import uk.gov.ons.ctp.integration.common.product.model.Product;
 import uk.gov.ons.ctp.integration.common.product.model.Product.DeliveryChannel;
 import uk.gov.ons.ctp.integration.common.product.model.Product.ProductGroup;
 import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient;
-import uk.gov.ons.ctp.integration.ratelimiter.model.RateLimitResponse;
 
 /**
  * This is a program for manually testing the client against an real/fake limiter.
@@ -36,6 +38,7 @@ public class RateLimiterClient_IT {
 
   private RestClient restClient;
   private RateLimiterClient client;
+  private CircuitBreaker circuitBreaker;
 
   private ObjectMapper objectMapper;
 
@@ -67,7 +70,22 @@ public class RateLimiterClient_IT {
       this.restClient =
           new RestClient(restClientConfig, httpErrorMapping, HttpStatus.INTERNAL_SERVER_ERROR);
 
-      this.client = new RateLimiterClient(this.restClient);
+      // Create minimalist circuit breaker implementation
+      this.circuitBreaker =
+          new CircuitBreaker() {
+            public <T> T run(Supplier<T> toRun, Function<Throwable, T> fallback) {
+              try {
+                // execute the code that the circuitBreaker is protecting
+                return toRun.get();
+              } catch (Throwable t) {
+                // execute the fallback Function)
+                fallback.apply(t);
+                return null;
+              }
+            }
+          };
+
+      this.client = new RateLimiterClient(this.restClient, circuitBreaker);
     }
   }
 
@@ -143,17 +161,14 @@ public class RateLimiterClient_IT {
       String telNo = useTelNo ? "0123 3434333" : null;
 
       // Get client to call /json endpoint
-      RateLimitResponse response =
-          client.checkFulfilmentRateLimit(
-              RateLimiterClient.Domain.RH,
-              product,
-              CaseType.HH,
-              ipAddress,
-              new UniquePropertyReferenceNumber("24234234"),
-              telNo);
-      System.out.println("Response:");
-      System.out.println(convertToJson(response));
-      actualHttpStatus = HttpStatus.valueOf(Integer.parseInt(response.getOverallCode()));
+      client.checkFulfilmentRateLimit(
+          RateLimiterClient.Domain.RH,
+          product,
+          CaseType.HH,
+          ipAddress,
+          new UniquePropertyReferenceNumber("24234234"),
+          telNo);
+      actualHttpStatus = HttpStatus.OK;
 
     } catch (ResponseStatusException e) {
       actualHttpStatus = e.getStatus();
@@ -174,11 +189,9 @@ public class RateLimiterClient_IT {
     HttpStatus actualHttpStatus;
     try {
       // Get client to call /json endpoint
-      RateLimitResponse response =
-          client.checkWebformRateLimit(RateLimiterClient.Domain.RH, "100.233.73.101");
+      client.checkWebformRateLimit(RateLimiterClient.Domain.RH, "100.233.73.101");
       System.out.println("Response:");
-      System.out.println(convertToJson(response));
-      actualHttpStatus = HttpStatus.valueOf(Integer.parseInt(response.getOverallCode()));
+      actualHttpStatus = HttpStatus.OK;
 
     } catch (ResponseStatusException e) {
       actualHttpStatus = e.getStatus();
@@ -189,9 +202,5 @@ public class RateLimiterClient_IT {
 
     assertEquals(expectedHttpStatus, actualHttpStatus);
     System.out.println();
-  }
-
-  private String convertToJson(Object o) throws JsonProcessingException {
-    return objectMapper.writeValueAsString(o);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClient_IT.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClient_IT.java
@@ -31,7 +31,7 @@ import uk.gov.ons.ctp.integration.ratelimiter.client.RateLimiterClient;
  *
  * <p>The hostname of the limiter should be set in the LIMITER_HOST environment variable. If this
  * environment variable is not set then the program doesn't do anything (and will therefore 'pass'
- * the test)
+ * the test). For running on a development machine set this to 'localhost'.
  */
 public class RateLimiterClient_IT {
   private String limiterHost;

--- a/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClient_IT.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/ratelimiterclient/RateLimiterClient_IT.java
@@ -190,13 +190,11 @@ public class RateLimiterClient_IT {
     try {
       // Get client to call /json endpoint
       client.checkWebformRateLimit(RateLimiterClient.Domain.RH, "100.233.73.101");
-      System.out.println("Response:");
       actualHttpStatus = HttpStatus.OK;
 
     } catch (ResponseStatusException e) {
       actualHttpStatus = e.getStatus();
       System.out.println("invokeWebformRateLimitCheck: Caught exception: " + actualHttpStatus);
-      System.out.println("Response:");
       System.out.println(e.getReason());
     }
 


### PR DESCRIPTION
Key changes:

- RHSvc used a circuit breaker when calling the RateLimiterClient. This is now the responsibility of the client and has been moved from RH.
- Updates to unit tests, as the circuit breaker effectively swallows up exceptions. The limit check mostly either works or throws a 429 exception.